### PR TITLE
chore: dont use fork, tripss supports prereleases now

### DIFF
--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -8,9 +8,10 @@ on:
         default: false
         description: use a prerelease instead of a regular release
 
-# -----------------------------------------------------------------------
-# NOTE: This workflow is deprecated in favor of create-github-release.yml
-# -----------------------------------------------------------------------
+# --------------------------------------------------------------------------
+# NOTE: This workflow is deprecated in favor of:
+# salesforcecli/github-workflows/.github/workflows/create-github-release.yml
+# --------------------------------------------------------------------------
 
 jobs:
   release:

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -8,6 +8,10 @@ on:
         default: false
         description: use a prerelease instead of a regular release
 
+# -----------------------------------------------------------------------
+# NOTE: This workflow is deprecated in favor of create-github-release.yml
+# -----------------------------------------------------------------------
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -29,13 +33,16 @@ jobs:
 
       - name: Conventional Changelog Action
         id: changelog
-        uses: salesforcecli/conventional-changelog-action@prereleases
+        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
         with:
           git-user-name: svc-cli-bot
           git-user-email: svc_cli_bot@salesforce.com
           github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           tag-prefix: ""
+          # Setting 'release-count' to 0 will keep ALL releases in the change log (no pruning)
           release-count: "0"
+          pre-release: ${{ inputs.prerelease }}
+          pre-release-identifier: ${{ steps.distTag.outputs.tag }}
           # ternary-ish: https://github.com/actions/runner/issues/409#issuecomment-752775072
           output-file: ${{ inputs.prerelease && 'false' || 'CHANGELOG.md' }} # If prerelease, do not write the changelog file
       - name: Create Github Release


### PR DESCRIPTION
Don't use fork, tripss supports prereleases now

[skip-validate-pr]