### PR TITLE
Replace flood-io/is-published-on-npm

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -46,9 +46,17 @@ jobs:
           ref: ${{ inputs.githubTag }}
       - uses: actions/setup-node@v3
         with:
-          cache: yarn
-      - uses: flood-io/is-published-on-npm@8478347e2650eb228d303975415458183d0a37e4
+          node-version: ${{ inputs.nodeVersion }}
+      - name: Is published
         id: is-published
+        run: |
+          RESPONSE=$(npm view .@${{ inputs.githubTag }} version --json --silent)
+
+          if [ "$RESPONSE" = "\"${{ inputs.githubTag }}\"" ]; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: echo "published said ${{ steps.is-published.outputs.published }}"


### PR DESCRIPTION
[flood-io/is-published-on-npm](https://github.com/flood-io/is-published-on-npm) is stale and uses the "[soon to be deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)" `set-output` format for setting values. 

This PR replaces it with a simple bash script before it breaks. 

Here is a similar shell script you can use for QA. 
- `cd` into a plugin dir (e.g. `plugin-info`)
- `touch npm-test.sh`
- Add the following
```sh
VERSION="2.1.11"
RESPONSE=$(npm view .@$VERSION version --json --silent)

# echo $RESPONSE
if [ "$RESPONSE" = "\"$VERSION\"" ]; then
  echo "published=true"
else
  echo "published=false"
fi
```
- `source npm-test.sh`
- Change `VERSION` to a published and non-published version

[@W-14488765@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14488765)
https://github.com/salesforcecli/github-workflows/pull/82