### PR TITLE
Prevent exit code 1

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Is published
         id: is-published
         run: |
-          RESPONSE=$(npm view .@${{ inputs.githubTag }} version --json --silent)
+          RESPONSE=$(npm view .@${{ inputs.githubTag }} version --json --silent || echo "Not published")
 
           if [ "$RESPONSE" = "\"${{ inputs.githubTag }}\"" ]; then
             echo "published=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Prevents the npm version check from exiting with a 1 (and ending the job)

<img width="852" alt="Screenshot 2023-11-15 at 4 36 04 PM" src="https://github.com/salesforcecli/github-workflows/assets/1715111/2f14d6c6-e766-4f0b-880d-3c4a40c0aea4">


[@W-14488765@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14488765)